### PR TITLE
Add location permission to Podfile for permission_handler macros

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -37,5 +37,12 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+            '$(inherited)',
+            ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
+            'PERMISSION_LOCATION=1'
+          ]
+    end
   end
 end


### PR DESCRIPTION
The current version of the Podfile does not specify the required parameters for the permission_handler package. When user press button "Request Location Permissions" nothing happened.

The permission_handler plugin use macros to control whether a permission is enabled. You must specify location permission in Podfile.

Permission_handler documentation - https://pub.dev/packages/permission_handler
