### PR TITLE
refactor: uses flutter result to return initialize method channel

### DIFF
--- a/android/src/main/java/ai/roam/roam_flutter/RoamFlutterPlugin.java
+++ b/android/src/main/java/ai/roam/roam_flutter/RoamFlutterPlugin.java
@@ -205,8 +205,7 @@ public class RoamFlutterPlugin implements FlutterPlugin, MethodCallHandler, Acti
            break;
 
          case METHOD_INITIALIZE:
-           final String publishKey = call.argument("publishKey");
-           Roam.initialize(this.context, publishKey);
+           initialize(call, result);
            break;
 
          case METHOD_ALLOW_MOCK_LOCATION:
@@ -963,7 +962,13 @@ public class RoamFlutterPlugin implements FlutterPlugin, MethodCallHandler, Acti
      }
   }
 
-    @Override
+  private void initialize(@NonNull MethodCall call, @NonNull Result result) {
+    final String publishKey = call.argument("publishKey");
+    Roam.initialize(this.context, publishKey);
+    result.success(true);
+  }
+
+  @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     this.context = null;
     channel.setMethodCallHandler(null);

--- a/ios/Classes/SwiftRoamFlutterPlugin.swift
+++ b/ios/Classes/SwiftRoamFlutterPlugin.swift
@@ -186,13 +186,11 @@ public class SwiftRoamFlutterPlugin: NSObject, FlutterPlugin, RoamDelegate {
         }
     }
 
-
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch (call.method) {
         case SwiftRoamFlutterPlugin.METHOD_INITIALIZE:
-            let arguments = call.arguments as! [String: Any]
-            let publishKey = arguments["publishKey"]  as! String;
-            Roam.initialize(publishKey)
+            initialize(call, result)
+
         case SwiftRoamFlutterPlugin.METHOD_CREATE_USER:
             let arguments = call.arguments as! [String: Any]
             let description = arguments["description"]  as! String;
@@ -773,7 +771,12 @@ public class SwiftRoamFlutterPlugin: NSObject, FlutterPlugin, RoamDelegate {
         }
     }
     
-    
+    private func initialize(_ call: FlutterMethodCall,_ result: @escaping FlutterResult) {
+        let arguments = call.arguments as! [String: Any]
+        let publishKey = arguments["publishKey"]  as! String;
+        Roam.initialize(publishKey)
+        result(true)
+    }
     
     //JSON encode
     


### PR DESCRIPTION
Uses `FlutterResult` on `SwiftRoamFlutterPlugin.swift` (iOS) and `Result` on `RoamFlutterPlugin.java` to return the initialize method channel.

With this refactor, we can use `await Roam.initialize(...)`, like:
```dart
await Roam.initialize(publishKey: "insert your publishable key");
debugPrint("Roam initialized");
```