### PR TITLE
fix: passing getUser exceptions to Method Channel

### DIFF
--- a/android/src/main/java/ai/roam/roam_flutter/RoamFlutterPlugin.java
+++ b/android/src/main/java/ai/roam/roam_flutter/RoamFlutterPlugin.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
+import android.util.Log;
 
 
 import com.google.gson.Gson;
@@ -309,27 +310,7 @@ public class RoamFlutterPlugin implements FlutterPlugin, MethodCallHandler, Acti
            break;
 
          case METHOD_GET_USER:
-           final String userId = call.argument("userId");
-           Roam.getUser(userId, new RoamCallback() {
-             @Override
-             public void onSuccess(RoamUser roamUser) {
-               JSONObject user = new JSONObject();
-               try {
-                 user.put("userId", roamUser.getUserId());
-                 user.put("description", roamUser.getDescription());
-                 String userText = user.toString();
-                 result.success(userText);
-               } catch (JSONException e) {
-                 e.printStackTrace();
-               }
-             }
-
-             @Override
-             public void onFailure(RoamError roamError) {
-               roamError.getMessage();
-               roamError.getCode();
-             }
-           });
+           getUser(call, result);
            break;
 
          case METHOD_TOGGLE_LISTENER:
@@ -963,7 +944,35 @@ public class RoamFlutterPlugin implements FlutterPlugin, MethodCallHandler, Acti
      }
   }
 
-    @Override
+  private void getUser(@NonNull MethodCall call, final Result result) {
+    final String userId = call.argument("userId");
+    Roam.getUser(userId, new RoamCallback() {
+      @Override
+      public void onSuccess(RoamUser roamUser) {
+        JSONObject user = new JSONObject();
+        try {
+          user.put("userId", roamUser.getUserId());
+          user.put("description", roamUser.getDescription());
+          String userText = user.toString();
+          result.success(userText);
+        } catch (JSONException e) {
+          e.printStackTrace();
+        }
+      }
+
+      @Override
+      public void onFailure(RoamError roamError) {
+        result.error(
+          "roam_" + roamError.getCode(),
+          roamError.getMessage(),
+          null
+        );
+      }
+    });
+  }
+
+
+  @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     this.context = null;
     channel.setMethodCallHandler(null);

--- a/ios/Classes/SwiftRoamFlutterPlugin.swift
+++ b/ios/Classes/SwiftRoamFlutterPlugin.swift
@@ -259,20 +259,8 @@ public class SwiftRoamFlutterPlugin: NSObject, FlutterPlugin, RoamDelegate {
                 }
             }
         case SwiftRoamFlutterPlugin.METHOD_GET_USER:
-            let arguments = call.arguments as! [String: Any]
-            let userId = arguments["userId"]  as! String;
-            Roam.getUser(userId) {(roamUser, error) in
-                let user: NSDictionary = [
-                    "userId": roamUser?.userId as Any,
-                    "description":roamUser?.userDescription as Any
-                ]
-                if let theJSONData = try? JSONSerialization.data(
-                    withJSONObject: user,
-                    options: []) {
-                    let theJSONText = String(data: theJSONData,encoding: .ascii)
-                    result(theJSONText)
-                }
-            }
+            getUser(call, result)
+        
         case SwiftRoamFlutterPlugin.METHOD_UPDATE_CURRENT_LOCATION:
             let arguments = call.arguments as! [String: Any]
             let accuracy = arguments["accuracy"]  as! Int;
@@ -772,8 +760,31 @@ public class SwiftRoamFlutterPlugin: NSObject, FlutterPlugin, RoamDelegate {
             result("iOS " + UIDevice.current.systemVersion)
         }
     }
-    
-    
+
+    private func getUser(_ call: FlutterMethodCall,_ result: @escaping FlutterResult) {
+        let arguments = call.arguments as! [String: Any]
+        let userId = arguments["userId"]  as! String;
+        Roam.getUser(userId) {(roamUser, error) in
+            if error != nil {
+                result(FlutterError.init(
+                   code: "roam_" + error!.code!,
+                   message: error!.message!,
+                   details: nil
+               ))
+                return
+            }
+            let user: NSDictionary = [
+                "userId": roamUser?.userId as Any,
+                "description":roamUser?.userDescription as Any
+            ]
+            if let theJSONData = try? JSONSerialization.data(
+                withJSONObject: user,
+                options: []) {
+                let theJSONText = String(data: theJSONData,encoding: .ascii)
+                result(theJSONText)
+            }
+        }
+    } 
     
     //JSON encode
     

--- a/lib/roam_flutter.dart
+++ b/lib/roam_flutter.dart
@@ -108,11 +108,11 @@ class Roam {
   /// Get User
   /// Accepts Roam User Id in String Format
   /// Returns Roam User
-  static Future<void> getUser(
-      {required String userId, required RoamUserCallBack callBack}) async {
+  static Future<String?> getUser({
+    required String userId,
+  }) async {
     final Map<String, dynamic> params = <String, dynamic>{'userId': userId};
-    final String? result = await _channel.invokeMethod(METHOD_GET_USER, params);
-    callBack(user: result);
+    return await _channel.invokeMethod(METHOD_GET_USER, params);
   }
 
   /// Toggle User Listener

--- a/lib/roam_flutter.dart
+++ b/lib/roam_flutter.dart
@@ -108,11 +108,11 @@ class Roam {
   /// Get User
   /// Accepts Roam User Id in String Format
   /// Returns Roam User
-  static Future<String?> getUser({
-    required String userId,
-  }) async {
+  static Future<void> getUser(
+      {required String userId, required RoamUserCallBack callBack}) async {
     final Map<String, dynamic> params = <String, dynamic>{'userId': userId};
-    return await _channel.invokeMethod(METHOD_GET_USER, params);
+    final String? result = await _channel.invokeMethod(METHOD_GET_USER, params);
+    callBack(user: result);
   }
 
   /// Toggle User Listener


### PR DESCRIPTION
Uses `FlutterResult` on `SwiftRoamFlutterPlugin.swift` (iOS) and `Result` on `RoamFlutterPlugin.java` to return for the flutter the errors of `getUser` method.

With this fix refactor, we can use `try catch`, like:
```dart
try {
  await Roam.getUser(
    userId: "",
    callBack: ({user}) => debugPrint(user),
  );
} catch (exception, stackTrace) {
  log(
    "Roam method invokation exception: "
    "methodName = getUser "
    "exception = ${exception.toString()}",
    stackTrace: stackTrace,
  );
}
```

Note for future improvement: could be better not have callbacks on this methods to allow this type of code:
```dart
final user = await Roam.getUser(userId: "");
debugPrint(user);
```